### PR TITLE
feat: Home Feed API 응답값으로 구현, 마이너 이슈 수정

### DIFF
--- a/src/Components/Feed.jsx
+++ b/src/Components/Feed.jsx
@@ -1,26 +1,51 @@
 import React from "react";
 import styled from "styled-components";
 import UserInfo from "./UserInfo";
+import { Link } from 'react-router-dom';
 
-const Feed = ({text, imgLink="./image/post-img-example.png", likeNum="0", chatNum="0", date="Date Loading"}) => {
+function Feed ({
+  profileImgSrc = "./image/basic-profile-img.png",
+  userName,
+  userAccountId,
+  text,
+  imgLink="./image/post-img-example.png",
+  likeNum="0",
+  chatNum="0",
+  date="Date Loading"
+}) {
   return (
     <Container>
-      <UserInfo />
+      <UserInfo
+        profileImgSrc = {profileImgSrc}
+        userName = {userName}
+        userAccountId = {userAccountId}
+      />
       <FeedContents>
         <FeedText>
           {text}
-          옷을 인생을 그러므로 없으면 것은 이상은 것은 우리의 위하여, 뿐이다.
-          이상의 청춘의 뼈 따뜻한 그들의 그와 약동하다. 대고, 못할 넣는 풍부하게
-          뛰노는 인생의 힘있다.
         </FeedText>
-        <FeedImage src={imgLink} alt="피드 이미지" />
+        { imgLink !== "" ?
+          <FeedImgWrap>
+            { imgLink.split(",").length > 1 ? 
+              <AmountTag>
+                +{imgLink.split(",").length - 1}
+              </AmountTag>
+            : null }
+            <FeedImg
+              src = {imgLink.split(",")[0]}
+              alt = "게시물 이미지"
+              />
+          </FeedImgWrap>
+            :
+          null
+        }
         <FeedLikeAndChat>
           <LikeButton>
-            <LikeImg src="./image/icon/icon-heart.png" alt="피드 이미지" />
+            <LikeImg src="./image/icon/icon-heart.png" alt="좋아요" />
             <LikeCount>{likeNum}</LikeCount>
           </LikeButton>
           <ChatButton>
-            <ChatImg src="./image/icon/icon-message-circle.png" alt="" />
+            <ChatImg src="./image/icon/icon-message-circle.png" alt="댓글" />
             <ChatCount>{chatNum}</ChatCount>
           </ChatButton>
         </FeedLikeAndChat>
@@ -46,11 +71,32 @@ const FeedText = styled.div`
   margin-bottom: 16px;
 `;
 
-const FeedImage = styled.img`
-  width: 280px;
-  border-radius: 15px;
-  margin-bottom: 12px;
+const FeedImgWrap = styled(Link)`
   cursor: pointer;
+  display: block;
+  position: relative;
+  margin-bottom: 12px;
+  width: 280px;
+  max-height: 300px;
+  border-radius: 15px;
+  overflow: hidden;
+`;
+const AmountTag = styled.span`
+  display: block;
+  position: absolute;
+  bottom: 13px;
+  right: 13px;
+  width: 26px;
+  height: 26px;
+  color: #fff;
+  text-align: center;
+  line-height: 26px;
+  font-size: 13px;
+  background-color: #0000006c;
+  border-radius: 15px;
+`;
+const FeedImg = styled.img`
+  width: calc(100% + 15px);
 `;
 
 const FeedLikeAndChat = styled.div`

--- a/src/Components/UserInfo.jsx
+++ b/src/Components/UserInfo.jsx
@@ -1,17 +1,21 @@
 import React from 'react'
 import styled from 'styled-components';
 
-const UserInfo = () => {
+function UserInfo({
+  profileImgSrc,
+  userName,
+  userAccountId
+}) {
   return (
     <>
     <UserInfoWrap>
       <ProfileWrap>
         <Avatar>
-          <Img src="./image/basic-profile-img.png" alt="" />
+          <Img src={profileImgSrc} alt="프로필 이미지" />
         </Avatar>
         <Info>
-          <Name>애월읍 위니브 감귤농장</Name>
-          <Email>@ weniv_Mandarin</Email>
+          <Name>{userName}</Name>
+          <AccountId>@{userAccountId}</AccountId>
         </Info>
       </ProfileWrap>
       <MoreButton>
@@ -22,7 +26,7 @@ const UserInfo = () => {
   );
 };
 
-const UserInfoWrap = styled.div`
+const UserInfoWrap = styled.article`
   display: flex;
   width: 100%;
   height: 42px;
@@ -30,13 +34,15 @@ const UserInfoWrap = styled.div`
   margin-bottom: 12px;
 `;
 
-const ProfileWrap = styled.div`
+const ProfileWrap = styled.article`
   display: flex;
 `;
 
 const Avatar = styled.a`
   width: 42px;
   height: 42px;
+  border-radius: 100%;
+  overflow: hidden;
   margin-right: 12px;
 `;
 
@@ -45,7 +51,9 @@ const Img = styled.img`
   height: 100%;
 `;
 
-const Info = styled.div`
+const Info = styled.article`
+  display: flex;
+  flex-direction: column;
 `;
 
 const Name = styled.div`
@@ -56,7 +64,7 @@ const Name = styled.div`
   font-size: 14px;
   `;
   
-  const Email = styled.div`
+  const AccountId = styled.article`
   display: flex;
   align-items: center;
   height: 50%;

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -1,20 +1,63 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import Feed from "../../Components/Feed";
 import HeaderHome from "../../Components/Home/HeaderHome";
 import NavBottom from "../../Components/NavBottom";
 import { Link } from 'react-router-dom';
 
-const Home = () => {
-  // const [hasFeed, sethasFeed] = useState(true);
+import axios from "axios";
+import store from "../../Store";
+
+function Home() {
   const [hasFeed, sethasFeed] = useState(false);
+  const [getFeedArray, setGetFeedArray] = useState([]);
+
+  function getFeed() {
+    const url = 'http://146.56.183.55:5050';
+    const token = store.getLocalStorage().token;
+    axios.get(`${url}/post/feed`, {
+        headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-type': 'application/json',
+        },
+    })
+    .then(res => {
+      setGetFeedArray(res.data.posts);
+      if (res.data.posts.length > 0) {
+        console.log(getFeedArray)
+        sethasFeed(true);
+      } else {
+        sethasFeed(false);
+      }
+    })
+    .catch(err => {
+      console.log('에러', err);
+    });
+  }
+
+  useEffect(() => {
+    getFeed();
+  }, []);
 
   const showFeed = () => {
     return (
       <FeedWrap>
-        <Feed />
-        <Feed />
-        <Feed />
+        { hasFeed ? 
+          getFeedArray.map( (value) => (
+            <Feed
+            profileImgSrc = {value.author.image}
+            userName = {value.author.username}
+            userAccountId = {value.author.accountname}
+            text = {value.content}
+            imgLink = {value.image}
+            likeNum = {value.heartCount}
+            chatNum = {value.commentCount}
+            date = {(value.createdAt).slice(0,10).replace("-", "년 ").replace("-", "월 ")+"일"}
+          />
+          ))
+          :
+          null
+        }
       </FeedWrap>
     );
   };

--- a/src/pages/Login/LoginMembership.jsx
+++ b/src/pages/Login/LoginMembership.jsx
@@ -3,7 +3,6 @@ import styled from "styled-components";
 import { Link, useHistory } from "react-router-dom";
 
 import axios from "axios";
-import store from "../../Store";
 import LoginProfile from "./LoginProfile";
 
 const LoginMembership = () => {
@@ -39,8 +38,7 @@ const LoginMembership = () => {
     axios.post(url + '/user', data)
       .then(res => {
         console.log('결과', res);
-        store.setLocalStorage(res.data.user);
-        history.push("/home");
+        history.push("/login/email");
       })
       .catch(err => {
         console.log('에러', err);

--- a/src/pages/Search/Search.jsx
+++ b/src/pages/Search/Search.jsx
@@ -68,7 +68,12 @@ const Search = () => {
 const Container = styled.section`
 `;
 const UserList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  height: 730px;
   padding: 20px 16px;
+  overflow-y: auto;
 `;
 
 export default Search;


### PR DESCRIPTION
## 세부 사항
- Home에서 팔로우한 유저의 게시물을 Feed 형태로 불러오기
- 불러온 게시물의 이미지 갯수가 2개 이상인 경우, 이미지 우측 하단에 태그 보이기
- Search 페이지에서 검색 결과가 많으면, 스크롤 보이기

### 마이너 이슈
- 회원가입을 마치면 로그인 화면으로 이동하기

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
